### PR TITLE
Update GH workflows to create releases automatically

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,10 +2,12 @@ name: rust-g
 on:
   push:
     branches:
-    - master
+      - master
+    tags:
+      - 'v*'
   pull_request:
     branches:
-    - master
+      - master
 jobs:
   build-windows:
     runs-on: windows-latest
@@ -47,3 +49,45 @@ jobs:
         with:
           name: rust_g
           path: target/i686-unknown-linux-gnu/release/librust_g.so
+  deploy:
+    name: Create Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build-windows, build-linux]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - uses: actions/download-artifact@v2
+        with:
+          name: rust_g.dll
+      - name: Upload rust_g.dll
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./rust_g.dll
+          asset_name: rust_g.dll
+          asset_content_type: application/octet-stream
+      - uses: actions/download-artifact@v2
+        with:
+          name: rust_g
+      - name: Upload librust_g.so
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./librust_g.so
+          asset_name: librust_g.so
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
GH Actions will now create a release with rust_g.dll and librust_g.so artifacts if a new tag is pushed that begins with v, i.e. `v0.4.3` for example. Releases will not be created otherwise